### PR TITLE
symfony/http-foundation 6.0 compatibility fix

### DIFF
--- a/src/Spryker/Zed/ManualOrderEntryGui/Communication/Service/ManualOrderEntryFormPluginFilter.php
+++ b/src/Spryker/Zed/ManualOrderEntryGui/Communication/Service/ManualOrderEntryFormPluginFilter.php
@@ -151,7 +151,7 @@ class ManualOrderEntryFormPluginFilter
      */
     protected function isFormSubmitted(ManualOrderEntryFormPluginInterface $formPlugin, Request $request): bool
     {
-        return ($request->request->get($formPlugin->getName()) !== null);
+        return $request->get($formPlugin->getName()) !== null;
     }
 
     /**


### PR DESCRIPTION
It appears that using symfony/http-foundation:6.0^ restricts from returning an array from the InputBag: https://github.com/symfony/http-foundation/blob/v6.2.7/InputBag.php#L37
